### PR TITLE
Platform options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-03-25
+
+### Added
+
+- Re-exported `FlutterSecureStorage` configuration types (`IOSOptions`, `AndroidOptions`, `KeychainAccessibility`) from main library export
+  - Allows consumers to configure platform-specific secure storage options without directly depending on `flutter_secure_storage`
+  - Enables iOS keychain accessibility configuration (e.g., `KeychainAccessibility.first_unlock`) through `hybrid_storage` package alone
+  - Supports Android encryption options configuration
+
+### Benefits
+
+- **Single dependency**: Projects only need to depend on `hybrid_storage`, not `flutter_secure_storage` directly
+- **Platform configuration**: Full access to iOS and Android secure storage configuration options
+- **Cleaner imports**: All types available from `package:hybrid_storage/hybrid_storage.dart`
+
+### Usage Example
+
+```dart
+import 'package:hybrid_storage/hybrid_storage.dart';  // Single import!
+
+final storage = HybridSecureStorageImpl(
+  FlutterSecureStorage(
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  ),
+);
+```
+
+### Migration Guide
+
+No breaking changes. Existing code continues to work. If you were previously importing `flutter_secure_storage` directly for configuration, you can now remove that dependency and import from `hybrid_storage` instead.
+
 ## [2.0.2] - 2026-02-27
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -147,6 +147,43 @@ await prefsStorage.writeBool(key: 'dark_mode', value: true);
 final isDarkMode = await prefsStorage.readBool(key: 'dark_mode');
 ```
 
+## Platform-Specific Configuration
+
+### Configuring Secure Storage Options
+
+You can configure platform-specific options for `HybridSecureStorageImpl` without directly depending on `flutter_secure_storage`. All necessary types are re-exported from `hybrid_storage`:
+
+```dart
+import 'package:hybrid_storage/hybrid_storage.dart';  // Single import needed!
+
+// iOS: Configure keychain accessibility
+final secureStorage = HybridSecureStorageImpl(
+  FlutterSecureStorage(
+    iOptions: IOSOptions(
+      accessibility: KeychainAccessibility.first_unlock,
+    ),
+  ),
+);
+
+// Android: Configure encryption options
+final secureStorage = HybridSecureStorageImpl(
+  FlutterSecureStorage(
+    aOptions: AndroidOptions(
+      encryptedSharedPreferences: true,
+    ),
+  ),
+);
+```
+
+**Available iOS Keychain Accessibility Options:**
+- `KeychainAccessibility.first_unlock` - Data accessible after first device unlock (recommended)
+- `KeychainAccessibility.unlocked` - Data only accessible when device is unlocked
+- `KeychainAccessibility.passcode` - Most restrictive, requires passcode
+- `KeychainAccessibility.unlocked_this_device` - Device-specific, unlocked only
+- And more...
+
+**Note:** You only need `hybrid_storage` in your `pubspec.yaml` - no need to add `flutter_secure_storage` as a direct dependency.
+
 ## Usage with Dependency Injection
 
 The library is DI-agnostic and works with any framework:

--- a/lib/hybrid_storage.dart
+++ b/lib/hybrid_storage.dart
@@ -4,3 +4,5 @@ export 'src/secure_storage/hybrid_secure_storage_impl.dart';
 export 'src/shared_preferences/hybrid_preferences_storage_impl.dart';
 export 'src/hive/hybrid_hive_storage_impl.dart';
 export 'src/utils/logger_config.dart';
+export 'package:flutter_secure_storage/flutter_secure_storage.dart'
+    show FlutterSecureStorage, IOSOptions, AndroidOptions, KeychainAccessibility;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: hybrid_storage
 description: Hybrid storage library for Flutter providing a unified API across multiple storage backends with logging support.
-version: 2.0.2
+version: 2.0.3
 homepage: https://github.com/rudoapps/hybrid-storage
 repository: https://github.com/rudoapps/hybrid-storage
 issue_tracker: https://github.com/rudoapps/hybrid-storage/issues


### PR DESCRIPTION
Re-export IOSOptions, AndroidOptions, and KeychainAccessibility from flutter_secure_storage to allow platform-specific configuration without requiring consumers to directly depend on flutter_secure_storage.

This enables projects to configure iOS keychain accessibility and Android encryption options using only hybrid_storage as a dependency.

- Bumped version to 2.0.3

No breaking changes - fully backward compatible.